### PR TITLE
Fix inventory detection when used with Convenient Chests

### DIFF
--- a/BetterCrafting/BetterCrafting.csproj
+++ b/BetterCrafting/BetterCrafting.csproj
@@ -76,18 +76,18 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180630\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="All" DependsOnTargets="Build">
     <Copy SourceFiles="$(MSBuildProjectDirectory)\categories.json" DestinationFolder="$(GamePath)\Mods\$(AssemblyName)" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\manifest.json" DestinationFolder="$(GamePath)\Mods\$(AssemblyName)" />
   </Target>
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180630\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180630\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180630\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0-beta-20180630\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -152,8 +152,6 @@ namespace BetterCrafting
                 Game1.mouseCursors,
                 new Rectangle(162, 440, 16, 16),
                 (float)Game1.pixelZoom, false);
-
-            this.UpdateInventory();
         }
 
         public void UpdateInventory()
@@ -998,6 +996,7 @@ namespace BetterCrafting
 
         public override void draw(SpriteBatch b)
         {
+            this.UpdateInventory();
             base.drawHorizontalPartition(b, this.yPositionOnScreen + IClickableMenu.borderWidth + IClickableMenu.spaceToClearTopBorder + Game1.tileSize * 4);
 
             var currentPage = this.GetCurrentPage();

--- a/BetterCrafting/packages.config
+++ b/BetterCrafting/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0-beta-20180630" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Sorry about the PM, didn't realize this WAS open source and on Github.

Also realized that it was already compilable with the latest SMAPI without any changes, it was my decompiler that was causing errors before.

Anyway this is the fix for Convenient Chests compatibility. Doesn't seem to affect the stock behavior at all.