### PR TITLE
Update for Stardew Valley 1.3.35 and SMAPI 3.0, various fixes

### DIFF
--- a/BetterCrafting/BetterCrafting.csproj
+++ b/BetterCrafting/BetterCrafting.csproj
@@ -11,9 +11,6 @@
     <AssemblyName>BetterCrafting</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -51,6 +48,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -73,18 +73,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="All" DependsOnTargets="Build">
-    <Copy SourceFiles="$(MSBuildProjectDirectory)\categories.json" DestinationFolder="$(GamePath)\Mods\$(AssemblyName)" />
-    <Copy SourceFiles="$(MSBuildProjectDirectory)\manifest.json" DestinationFolder="$(GamePath)\Mods\$(AssemblyName)" />
-  </Target>
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
 </Project>

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -1,19 +1,16 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
-using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using static BetterCrafting.CategoryManager;
 
 namespace BetterCrafting
 {
-    class BetterCraftingPage : CraftingPage
+    internal class BetterCraftingPage : CraftingPage
     {
         private const int WIDTH = 800;
         private const string AVAILABLE = "a";
@@ -105,7 +102,7 @@ namespace BetterCrafting
                 var y = this.yPositionOnScreen + tabPad + catIndex * (height + categorySpacing);
 
                 var c = new ClickableComponent(
-                    new Rectangle((int) x, (int) y, (int) width, (int) height),
+                    new Rectangle((int)x, (int)y, (int)width, (int)height),
                     category.Equals(this.selectedCategory) ? UNAVAILABLE : AVAILABLE, catName);
                 c.myID = id;
                 c.upNeighborID = id - 1;
@@ -124,7 +121,7 @@ namespace BetterCrafting
                     Game1.tileSize, 104),
                 Game1.mouseCursors,
                 new Rectangle(669, 261, 16, 26),
-                (float)Game1.pixelZoom, false);
+                Game1.pixelZoom, false);
 
             this.throwComp = new ClickableComponent(
                 new Rectangle(
@@ -143,7 +140,7 @@ namespace BetterCrafting
                 "Old Crafting Menu",
                 Game1.mouseCursors,
                 new Rectangle(162, 440, 16, 16),
-                (float)Game1.pixelZoom, false);
+                Game1.pixelZoom, false);
         }
 
         public void UpdateInventory()
@@ -233,7 +230,7 @@ namespace BetterCrafting
                     : Game1.getSourceRectForStandardTileSheet(
                         Game1.objectSpriteSheet,
                         recipe.getIndexOfMenuView(), 16, 16),
-                    (float)Game1.pixelZoom,
+                    Game1.pixelZoom,
                     false);
 
                 this.recipes[category][pageMap[category]].Add(c, recipe);
@@ -362,7 +359,7 @@ namespace BetterCrafting
                 this.recipePage += 1;
 
                 Game1.playSound("shwip");
-            }            
+            }
 
             this.UpdateScrollButtons();
         }
@@ -580,7 +577,7 @@ namespace BetterCrafting
                 else
                 {
                     this.inventory.applyMovementKey(direction);
-                }                
+                }
 
                 return;
             }
@@ -1047,7 +1044,7 @@ namespace BetterCrafting
             this.trashCan.draw(b);
             b.Draw(
                 Game1.mouseCursors,
-                new Vector2((float)(this.trashCan.bounds.X + 60), (float)(this.trashCan.bounds.Y + 40)),
+                new Vector2(this.trashCan.bounds.X + 60, this.trashCan.bounds.Y + 40),
                 new Rectangle(686, 256, 18, 10),
                 Color.White,
                 this.trashCanLidRotation,
@@ -1080,8 +1077,8 @@ namespace BetterCrafting
             {
                 this.heldItem.drawInMenu(b,
                     new Vector2(
-                        (float)(Game1.getOldMouseX() + Game1.tileSize / 4),
-                        (float)(Game1.getOldMouseY() + Game1.tileSize / 4)),
+                        Game1.getOldMouseX() + Game1.tileSize / 4,
+                        Game1.getOldMouseY() + Game1.tileSize / 4),
                     1f);
             }
 

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -276,7 +276,7 @@ namespace BetterCrafting
         private Dictionary<ClickableTextureComponent, CraftingRecipe> GetCurrentPage()
         {
             var craftingPages = this.recipes[this.selectedCategory];
-            if (this.recipePage >= craftingPages.Count)
+            if (this.recipePage >= craftingPages.Count || this.recipePage < 0)
             {
                 this.recipePage = 0;
             }
@@ -762,7 +762,8 @@ namespace BetterCrafting
 
         public override void performHoverAction(int x, int y)
         {
-
+            this.hoverTitle = "";
+            this.hoverText = "";
             this.hoverRecipe = null;
             this.hoverItem = this.inventory.hover(x, y, this.hoverItem);
 
@@ -770,11 +771,6 @@ namespace BetterCrafting
             {
                 this.hoverTitle = this.inventory.hoverTitle;
                 this.hoverText = this.inventory.hoverText;
-            }
-            else
-            {
-                this.hoverTitle = "";
-                this.hoverText = "";
             }
 
             var currentPage = this.GetCurrentPage();

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -13,7 +13,7 @@ using static BetterCrafting.CategoryManager;
 
 namespace BetterCrafting
 {
-    class BetterCraftingPage : IClickableMenu
+    class CraftingPage : StardewValley.Menus.CraftingPage
     {
         private const int WIDTH = 800;
         private const string AVAILABLE = "a";
@@ -28,21 +28,13 @@ namespace BetterCrafting
 
         private CategoryManager categoryManager;
 
-        private InventoryMenu inventory;
-
         private Dictionary<ItemCategory, List<Dictionary<ClickableTextureComponent, CraftingRecipe>>> recipes;
         private Dictionary<ClickableComponent, ItemCategory> categories;
-
-        private ClickableTextureComponent upButton;
-        private ClickableTextureComponent downButton;
 
         private ClickableComponent[] selectables;
 
         private ItemCategory selectedCategory;
         private int recipePage;
-
-        private ClickableTextureComponent trashCan;
-        private float trashCanLidRotation;
 
         private ClickableComponent throwComp;
 
@@ -63,7 +55,7 @@ namespace BetterCrafting
         private int snappedId = 0;
         private int snappedSection = 1;
 
-        public BetterCraftingPage(ModEntry betterCrafting, CategoryData categoryData, Nullable<ItemCategory> defaultCategory)
+        public CraftingPage(ModEntry betterCrafting, CategoryData categoryData, Nullable<ItemCategory> defaultCategory)
             : base(Game1.activeClickableMenu.xPositionOnScreen, Game1.activeClickableMenu.yPositionOnScreen, Game1.activeClickableMenu.width, Game1.activeClickableMenu.height)
         {
             this.betterCrafting = betterCrafting;
@@ -914,9 +906,8 @@ namespace BetterCrafting
                 Game1.playSound("select");
 
                 GameMenu gameMenu = (GameMenu)Game1.activeClickableMenu;
-                var pages = this.betterCrafting.Helper.Reflection.GetFieldValue<List<IClickableMenu>>(gameMenu, "pages");
-                pages[gameMenu.currentTab] = new CraftingPage(this.xPositionOnScreen, this.yPositionOnScreen, this.width, this.height, false);
-
+                BetterCrafting.ModEntry.setOldMenu(true);
+                Game1.activeClickableMenu = new GameMenu(gameMenu.currentTab);
                 return;
             }
 

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -749,7 +749,6 @@ namespace BetterCrafting
 
         public override void receiveScrollWheelAction(int direction)
         {
-            base.receiveScrollWheelAction(direction);
 
             if (direction > 0)
             {
@@ -763,7 +762,6 @@ namespace BetterCrafting
 
         public override void performHoverAction(int x, int y)
         {
-            base.performHoverAction(x, y);
 
             this.hoverRecipe = null;
             this.hoverItem = this.inventory.hover(x, y, this.hoverItem);
@@ -860,7 +858,6 @@ namespace BetterCrafting
 
         public override void receiveLeftClick(int x, int y, bool playSound = true)
         {
-            base.receiveLeftClick(x, y, playSound);
 
             this.heldItem = this.inventory.leftClick(x, y, this.heldItem);
 
@@ -989,7 +986,6 @@ namespace BetterCrafting
         public override void draw(SpriteBatch b)
         {
             this.UpdateInventory();
-            base.drawHorizontalPartition(b, this.yPositionOnScreen + IClickableMenu.borderWidth + IClickableMenu.spaceToClearTopBorder + Game1.tileSize * 4);
 
             var currentPage = this.GetCurrentPage();
 
@@ -1054,8 +1050,6 @@ namespace BetterCrafting
                 Game1.pixelZoom,
                 SpriteEffects.None,
                 0.86f);
-
-            base.drawMouse(b);
 
             if (this.hoverItem != null)
             {

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -13,7 +13,7 @@ using static BetterCrafting.CategoryManager;
 
 namespace BetterCrafting
 {
-    class CraftingPage : StardewValley.Menus.CraftingPage
+    class BetterCraftingPage : CraftingPage
     {
         private const int WIDTH = 800;
         private const string AVAILABLE = "a";
@@ -55,7 +55,7 @@ namespace BetterCrafting
         private int snappedId = 0;
         private int snappedSection = 1;
 
-        public CraftingPage(ModEntry betterCrafting, CategoryData categoryData, Nullable<ItemCategory> defaultCategory)
+        public BetterCraftingPage(ModEntry betterCrafting, CategoryData categoryData, Nullable<ItemCategory> defaultCategory)
             : base(Game1.activeClickableMenu.xPositionOnScreen, Game1.activeClickableMenu.yPositionOnScreen, Game1.activeClickableMenu.width, Game1.activeClickableMenu.height)
         {
             this.betterCrafting = betterCrafting;

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -889,11 +889,15 @@ namespace BetterCrafting
 
             foreach (var c in currentPage.Keys)
             {
-                if (c.containsPoint(x, y)
-                    && c.hoverText.Equals(AVAILABLE)
-                    && currentPage[c].doesFarmerHaveIngredientsInInventory())
+                int num = Game1.oldKBState.IsKeyDown(Keys.LeftShift) ? 5 : 1;
+                for (int index = 0; index < num; ++index)
                 {
-                    this.clickCraftingRecipe(c, true);
+                    if (c.containsPoint(x, y)
+                        && c.hoverText.Equals(AVAILABLE)
+                        && currentPage[c].doesFarmerHaveIngredientsInInventory())
+                    {
+                        this.clickCraftingRecipe(c, index == 0 ? true : false);
+                    }
                 }
             }
 

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -906,7 +906,7 @@ namespace BetterCrafting
                 Game1.playSound("select");
 
                 GameMenu gameMenu = (GameMenu)Game1.activeClickableMenu;
-                BetterCrafting.ModEntry.setOldMenu(true);
+                ModEntry.oldMenu = true;
                 Game1.activeClickableMenu = new GameMenu(gameMenu.currentTab);
                 return;
             }

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -998,6 +998,8 @@ namespace BetterCrafting
                 if (c.hoverText.Equals(AVAILABLE))
                 {
                     c.draw(b, Color.White, 0.89f);
+                    if (currentPage[c].numberProducedPerCraft > 1)
+                        NumberSprite.draw(currentPage[c].numberProducedPerCraft, b, new Vector2((float)(c.bounds.X + 64 - 2), (float)(c.bounds.Y + 64 - 2)), Color.Red, (float)(0.5 * ((double)c.scale / 4.0)), 0.97f, 1f, 0, 0);
                 }
                 else if (c.hoverText.Equals(UNKNOWN))
                 {

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -152,8 +152,6 @@ namespace BetterCrafting
                 Game1.mouseCursors,
                 new Rectangle(162, 440, 16, 16),
                 (float)Game1.pixelZoom, false);
-
-            this.UpdateInventory();
         }
 
         public void UpdateInventory()
@@ -1002,6 +1000,7 @@ namespace BetterCrafting
 
         public override void draw(SpriteBatch b)
         {
+            this.UpdateInventory();
             base.drawHorizontalPartition(b, this.yPositionOnScreen + IClickableMenu.borderWidth + IClickableMenu.spaceToClearTopBorder + Game1.tileSize * 4);
 
             var currentPage = this.GetCurrentPage();

--- a/BetterCrafting/BetterCraftingPage.cs
+++ b/BetterCrafting/BetterCraftingPage.cs
@@ -905,25 +905,20 @@ namespace BetterCrafting
                 return;
             }
 
-            if (this.trashCan.containsPoint(x, y) && this.heldItem != null && this.heldItem.canBeTrashed())
+            if (this.trashCan != null && this.trashCan.containsPoint(x, y) && (this.heldItem != null && this.heldItem.canBeTrashed()))
             {
                 if (this.heldItem is StardewValley.Object && Game1.player.specialItems.Contains((this.heldItem as StardewValley.Object).ParentSheetIndex))
-                {
                     Game1.player.specialItems.Remove((this.heldItem as StardewValley.Object).ParentSheetIndex);
-                }
-                this.heldItem = null;
+                this.heldItem = (Item)null;
                 Game1.playSound("trashcan");
-
-                return;
             }
-
-            if (this.heldItem != null && !this.isWithinBounds(x, y) && this.heldItem.canBeDropped())
+            else
             {
-                Game1.playSound("throwDownItem");
-                Game1.createItemDebris(this.heldItem, Game1.player.getStandingPosition(), Game1.player.facingDirection);
-                this.heldItem = null;
-
-                return;
+                if (this.heldItem == null || this.isWithinBounds(x, y) || !this.heldItem.canBeTrashed())
+                    return;
+                Game1.playSound("throwDownITem");
+                Game1.createItemDebris(this.heldItem, Game1.player.getStandingPosition(), Game1.player.FacingDirection, (GameLocation)null, -1);
+                this.heldItem = (Item)null;
             }
         }
 

--- a/BetterCrafting/CategoryData.cs
+++ b/BetterCrafting/CategoryData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace BetterCrafting
 {

--- a/BetterCrafting/CategoryManager.cs
+++ b/BetterCrafting/CategoryManager.cs
@@ -1,10 +1,7 @@
 ﻿using StardewModdingAPI;
 using StardewValley;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BetterCrafting
 {
@@ -55,7 +52,7 @@ namespace BetterCrafting
                 {
                     this.data.categoryNames.Add("misc", "Misc");
                 }
-                
+
                 this.itemCategories.Add(new ItemCategory("misc"));
             }
         }

--- a/BetterCrafting/ModEntry.cs
+++ b/BetterCrafting/ModEntry.cs
@@ -1,5 +1,6 @@
 ﻿using StardewModdingAPI;
 using StardewModdingAPI.Events;
+using StardewValley;
 using StardewValley.Menus;
 using System;
 using System.Collections.Generic;
@@ -25,6 +26,7 @@ namespace BetterCrafting
             }
 
             MenuEvents.MenuChanged += MenuChanged;
+            PlayerEvents.InventoryChanged += InventoryChanged;
         }
 
         private void MenuChanged(object sender, EventArgsClickableMenuChanged e)
@@ -37,6 +39,19 @@ namespace BetterCrafting
             }
             else
                 oldMenu = false;
+        }
+
+        private void InventoryChanged(object sender, EventArgsInventoryChanged e)
+        {
+            if (Game1.activeClickableMenu is GameMenu gameMenu && !oldMenu)
+            {
+                var craftingTabNum = gameMenu.getTabNumberFromName("crafting");
+                if (gameMenu.currentTab == craftingTabNum)
+                {
+                    var pages = this.Helper.Reflection.GetFieldValue<List<IClickableMenu>>(gameMenu, "pages");
+                    ((BetterCraftingPage)pages[craftingTabNum]).UpdateInventory();
+                }
+            }
         }
     }
 }

--- a/BetterCrafting/ModEntry.cs
+++ b/BetterCrafting/ModEntry.cs
@@ -2,18 +2,20 @@
 using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Menus;
-using System;
 using System.Collections.Generic;
 using static BetterCrafting.CategoryManager;
 
 namespace BetterCrafting
 {
+    /// <summary>The mod entry class loaded by SMAPI.</summary>
     public class ModEntry : Mod
     {
         public static bool oldMenu = false;
         private CategoryData categoryData;
-        public Nullable<ItemCategory> lastCategory;
+        public ItemCategory? lastCategory;
 
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
             this.categoryData = this.Helper.Data.ReadJsonFile<CategoryData>("categories.json");
@@ -25,34 +27,42 @@ namespace BetterCrafting
                 this.categoryData = new CategoryData();
             }
 
-            MenuEvents.MenuChanged += MenuChanged;
-            MenuEvents.MenuClosed += MenuClosed;
-            PlayerEvents.InventoryChanged += InventoryChanged;
+            helper.Events.Display.MenuChanged += OnMenuChanged;
+            helper.Events.Player.InventoryChanged += OnInventoryChanged;
         }
 
-        private void MenuChanged(object sender, EventArgsClickableMenuChanged e)
+        /// <summary>Raised after a game menu is opened, closed, or replaced.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnMenuChanged(object sender, MenuChangedEventArgs e)
         {
-            if (e.NewMenu is GameMenu gameMenu && !oldMenu)
+            switch (e.NewMenu)
             {
-                var craftingTabNum = gameMenu.getTabNumberFromName("crafting");
-                var pages = this.Helper.Reflection.GetFieldValue<List<IClickableMenu>>(gameMenu, "pages");
-                pages[craftingTabNum] = new BetterCraftingPage(this, this.categoryData, this.lastCategory);
+                case null:
+                    oldMenu = false;
+                    break;
+
+                case GameMenu gameMenu when !oldMenu:
+                    {
+                        var craftingTabNum = gameMenu.getTabNumberFromName("crafting");
+                        var pages = this.Helper.Reflection.GetFieldValue<List<IClickableMenu>>(gameMenu, "pages");
+                        pages[craftingTabNum] = new BetterCraftingPage(this, this.categoryData, this.lastCategory);
+                        break;
+                    }
             }
         }
 
-        private void MenuClosed(object sender, EventArgsClickableMenuClosed e)
+        /// <summary>Raised after items are added or removed to a player's inventory.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnInventoryChanged(object sender, InventoryChangedEventArgs e)
         {
-            oldMenu = false;
-        }
-        
-        private void InventoryChanged(object sender, EventArgsInventoryChanged e)
-        {
-            if (Game1.activeClickableMenu is GameMenu gameMenu && !oldMenu)
+            if (e.IsLocalPlayer && Game1.activeClickableMenu is GameMenu gameMenu && !oldMenu)
             {
-                var craftingTabNum = gameMenu.getTabNumberFromName("crafting");
+                int craftingTabNum = gameMenu.getTabNumberFromName("crafting");
                 if (gameMenu.currentTab == craftingTabNum)
                 {
-                    var pages = this.Helper.Reflection.GetFieldValue<List<IClickableMenu>>(gameMenu, "pages");
+                    List<IClickableMenu> pages = this.Helper.Reflection.GetFieldValue<List<IClickableMenu>>(gameMenu, "pages");
                     ((BetterCraftingPage)pages[craftingTabNum]).UpdateInventory();
                 }
             }

--- a/BetterCrafting/ModEntry.cs
+++ b/BetterCrafting/ModEntry.cs
@@ -38,7 +38,7 @@ namespace BetterCrafting
             {
                 var craftingTabNum = gameMenu.getTabNumberFromName("crafting");
                 var pages = this.Helper.Reflection.GetFieldValue<List<IClickableMenu>>(gameMenu, "pages");
-                pages[craftingTabNum] = new CraftingPage(this, this.categoryData, this.lastCategory);
+                pages[craftingTabNum] = new BetterCraftingPage(this, this.categoryData, this.lastCategory);
             }
             else
                 oldMenu = false;

--- a/BetterCrafting/ModEntry.cs
+++ b/BetterCrafting/ModEntry.cs
@@ -19,7 +19,7 @@ namespace BetterCrafting
 
         public override void Entry(IModHelper helper)
         {
-            this.categoryData = this.Helper.ReadJsonFile<CategoryData>("categories.json");
+            this.categoryData = this.Helper.Data.ReadJsonFile<CategoryData>("categories.json");
             if (this.categoryData == null)
             {
                 this.Monitor.Log("Failed to read category data from 'categories.json'", LogLevel.Error);

--- a/BetterCrafting/ModEntry.cs
+++ b/BetterCrafting/ModEntry.cs
@@ -26,6 +26,7 @@ namespace BetterCrafting
             }
 
             MenuEvents.MenuChanged += MenuChanged;
+            MenuEvents.MenuClosed += MenuClosed;
             PlayerEvents.InventoryChanged += InventoryChanged;
         }
 
@@ -37,10 +38,13 @@ namespace BetterCrafting
                 var pages = this.Helper.Reflection.GetFieldValue<List<IClickableMenu>>(gameMenu, "pages");
                 pages[craftingTabNum] = new BetterCraftingPage(this, this.categoryData, this.lastCategory);
             }
-            else
-                oldMenu = false;
         }
 
+        private void MenuClosed(object sender, EventArgsClickableMenuClosed e)
+        {
+            oldMenu = false;
+        }
+        
         private void InventoryChanged(object sender, EventArgsInventoryChanged e)
         {
             if (Game1.activeClickableMenu is GameMenu gameMenu && !oldMenu)

--- a/BetterCrafting/ModEntry.cs
+++ b/BetterCrafting/ModEntry.cs
@@ -14,6 +14,7 @@ namespace BetterCrafting
 {
     public class ModEntry : Mod
     {
+        private static bool oldMenu = false;
         private CategoryData categoryData;
         public Nullable<ItemCategory> lastCategory;
 
@@ -29,30 +30,23 @@ namespace BetterCrafting
             }
 
             MenuEvents.MenuChanged += MenuChanged;
-            PlayerEvents.InventoryChanged += InventoryChanged;
         }
 
         private void MenuChanged(object sender, EventArgsClickableMenuChanged e)
         {
-            if (e.NewMenu is GameMenu gameMenu)
+            if (e.NewMenu is GameMenu gameMenu && !oldMenu)
             {
                 var craftingTabNum = gameMenu.getTabNumberFromName("crafting");
                 var pages = this.Helper.Reflection.GetFieldValue<List<IClickableMenu>>(gameMenu, "pages");
-                pages[craftingTabNum] = new BetterCraftingPage(this, this.categoryData, this.lastCategory);
+                pages[craftingTabNum] = new CraftingPage(this, this.categoryData, this.lastCategory);
             }
+            else
+                oldMenu = false;
         }
 
-        private void InventoryChanged(object sender, EventArgsInventoryChanged e)
+        public static void setOldMenu(bool oldMenuActive = false)
         {
-            if (Game1.activeClickableMenu is GameMenu gameMenu)
-            {
-                var craftingTabNum = gameMenu.getTabNumberFromName("crafting");
-                if (gameMenu.currentTab == craftingTabNum)
-                {
-                    var pages = this.Helper.Reflection.GetFieldValue<List<IClickableMenu>>(gameMenu, "pages");
-                    ((BetterCraftingPage)pages[craftingTabNum]).UpdateInventory();
-                }
-            }
+            oldMenu = oldMenuActive;
         }
     }
 }

--- a/BetterCrafting/ModEntry.cs
+++ b/BetterCrafting/ModEntry.cs
@@ -14,7 +14,7 @@ namespace BetterCrafting
 {
     public class ModEntry : Mod
     {
-        private static bool oldMenu = false;
+        public static bool oldMenu = false;
         private CategoryData categoryData;
         public Nullable<ItemCategory> lastCategory;
 
@@ -42,11 +42,6 @@ namespace BetterCrafting
             }
             else
                 oldMenu = false;
-        }
-
-        public static void setOldMenu(bool oldMenuActive = false)
-        {
-            oldMenu = oldMenuActive;
         }
     }
 }

--- a/BetterCrafting/ModEntry.cs
+++ b/BetterCrafting/ModEntry.cs
@@ -1,13 +1,8 @@
-﻿using Microsoft.Xna.Framework;
-using StardewModdingAPI;
+﻿using StardewModdingAPI;
 using StardewModdingAPI.Events;
-using StardewValley;
 using StardewValley.Menus;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using static BetterCrafting.CategoryManager;
 
 namespace BetterCrafting

--- a/BetterCrafting/Properties/AssemblyInfo.cs
+++ b/BetterCrafting/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/BetterCrafting/ReflectionExtension.cs
+++ b/BetterCrafting/ReflectionExtension.cs
@@ -1,13 +1,8 @@
 ﻿using StardewModdingAPI;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BetterCrafting
 {
-    static class ReflectionExtension
+    internal static class ReflectionExtension
     {
         public static TValue GetFieldValue<TValue>(this IReflectionHelper reflection, object obj, string name, bool required = true)
         {

--- a/BetterCrafting/ReflectionExtension.cs
+++ b/BetterCrafting/ReflectionExtension.cs
@@ -11,7 +11,7 @@ namespace BetterCrafting
     {
         public static TValue GetFieldValue<TValue>(this IReflectionHelper reflection, object obj, string name, bool required = true)
         {
-            return reflection.GetPrivateField<TValue>(obj, name, required).GetValue();
+            return reflection.GetField<TValue>(obj, name, required).GetValue();
         }
     }
 }

--- a/BetterCrafting/categories.json
+++ b/BetterCrafting/categories.json
@@ -17,17 +17,17 @@
 			"Deluxe Speed-Gro",
 			"Basic Retaining Soil",
 			"Quality Retaining Soil",
-			
+
 			"Spring Seeds",
 			"Summer Seeds",
 			"Fall Seeds",
 			"Winter Seeds",
 			"Ancient Seeds",
-			
+
 			"Sprinkler",
 			"Quality Sprinkler",
 			"Iridium Sprinkler",
-			
+
 			"Scarecrow",
 			"Garden Pot"
 		],
@@ -47,7 +47,7 @@
 			"Stone Fence",
 			"Iron Fence",
 			"Hardwood Fence",
-			
+
 			"Wood Path",
 			"Wood Floor",
 			"Weathered Floor",
@@ -88,7 +88,7 @@
 			"Slime Egg-Press",
 			"Tapper",
 			"Worm Bin",
-			
+
 			"Mayonnaise Machine",
 			"Bee House",
 			"Preserves Jar",

--- a/BetterCrafting/manifest.json
+++ b/BetterCrafting/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
    "Name": "BetterCrafting",
    "Author": "RedstoneBoy",
-   "Version": "1.2",
+   "Version": "1.2.1-unofficial.1-kastallia",
    "Description": "Better crafting gui.",
    "UniqueID": "RedstoneBoy.BetterCrafting",
    "EntryDll": "BetterCrafting.dll",

--- a/BetterCrafting/manifest.json
+++ b/BetterCrafting/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
-   "Name": "BetterCrafting",
+   "Name": "Better Crafting",
    "Author": "RedstoneBoy",
-   "Version": "1.2.1-unofficial.1-kastallia",
-   "Description": "Better crafting gui.",
+   "Version": "1.2.1",
+   "Description": "Better crafting GUI.",
    "UniqueID": "RedstoneBoy.BetterCrafting",
    "EntryDll": "BetterCrafting.dll",
-   "MinimumApiVersion": "2.0",
+   "MinimumApiVersion": "2.10.2",
    "UpdateKeys": [ "Nexus:2504", "GitHub:RedstoneBoy/BetterCrafting" ]
 }

--- a/BetterCrafting/packages.config
+++ b/BetterCrafting/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.2.0 targetFramework="net45" />
 </packages>

--- a/BetterCrafting/packages.config
+++ b/BetterCrafting/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.2.0 targetFramework="net45" />
-</packages>


### PR DESCRIPTION
This pull request mainly...

* Updates the code for SMAPI 3.0 and Stardew Valley 1.3.33–35.
* Fixes some vanilla logic not applied (which includes shift-click crafting items in groups of 5, and the tooltips showing the number crafted).
* Fixes compatibility with mods that affect the crafting menu (including Convenient Chests and StackSplitX).
* Performs some minor formatting & refactoring.

This includes the changes from @Kastallia's and @PhantomGamers' unofficial updates. I assumed `master` is the main branch since it has your latest changes, but I can rebase onto `beta` instead if needed.

Let me know if you want me to change anything!